### PR TITLE
Missing long description parameter in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,17 @@
 import setuptools
 
+long_description: str
+
+with open("README.md", "r", encoding="utf-8") as readme_file:
+    long_description = readme_file.read()
+
 setuptools.setup(
   name = 'appwrite',
   packages = ['appwrite', 'appwrite/services'],
   version = '1.1.0',
   license='BSD-3-Clause',
+  long_description=long_description,
+  long_description_content_type="text/markdown",
   description = 'Appwrite is an open-source self-hosted backend server that abstract and simplify complex and repetitive development tasks behind a very simple REST API',
   author = 'Appwrite Team',
   author_email = 'team@appwrite.io',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The https://pypi.org/project/appwrite/ fails to load the README.md content as there was no long description parameter for reading the file previously. 
## Test Plan

I read through documentation and need help verifying these changes on the actual project description page.

## Related PRs and Issues

Related to issue [#4304](https://github.com/appwrite/appwrite/issues/4304)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes