### PR TITLE
chore: bump SDK version to 19.2.0

### DIFF
--- a/appwrite/client.py
+++ b/appwrite/client.py
@@ -17,11 +17,11 @@ class Client:
         self._endpoint = 'https://cloud.appwrite.io/v1'
         self._global_headers = {
             'content-type': '',
-            'user-agent' : f'AppwritePythonSDK/19.1.0 ({platform.uname().system}; {platform.uname().version}; {platform.uname().machine})',
+            'user-agent' : f'AppwritePythonSDK/19.2.0 ({platform.uname().system}; {platform.uname().version}; {platform.uname().machine})',
             'x-sdk-name': 'Python',
             'x-sdk-platform': 'server',
             'x-sdk-language': 'python',
-            'x-sdk-version': '19.1.0',
+            'x-sdk-version': '19.2.0',
             'X-Appwrite-Response-Format' : '1.9.5',
         }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "appwrite"
-version = "19.1.0"
+version = "19.2.0"
 description = "Appwrite is an open-source self-hosted backend server that abstracts and simplifies complex and repetitive development tasks behind a very simple REST API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r", encoding="utf-8") as readme_file_desc:
 setuptools.setup(
   name = 'appwrite',
   packages = setuptools.find_packages(),
-  version = '19.1.0',
+  version = '19.2.0',
   license='BSD-3-Clause',
   description = 'Appwrite is an open-source self-hosted backend server that abstracts and simplifies complex and repetitive development tasks behind a very simple REST API',
   long_description = long_description,
@@ -18,7 +18,7 @@ setuptools.setup(
   maintainer = 'Appwrite Team',
   maintainer_email = 'team@appwrite.io',
   url = 'https://appwrite.io/support',
-  download_url='https://github.com/appwrite/sdk-for-python/archive/19.1.0.tar.gz',
+  download_url='https://github.com/appwrite/sdk-for-python/archive/19.2.0.tar.gz',
   install_requires=[
     'requests',
     'pydantic>=2,<3',


### PR DESCRIPTION
This PR bumps SDK version metadata to 19.2.0 after the concurrent chunk upload update.